### PR TITLE
Feat blackboard conditions actions

### DIFF
--- a/behavior_tree/package.xml
+++ b/behavior_tree/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>behavior_tree_core</run_depend>
   <run_depend>behavior_tree_leaves</run_depend>
+  <run_depend>behavior_tree_msgs</run_depend>
   <export>
     <metapackage/>
   </export>

--- a/behavior_tree_core/CMakeLists.txt
+++ b/behavior_tree_core/CMakeLists.txt
@@ -6,6 +6,7 @@ project(behavior_tree_core)
 find_package(catkin REQUIRED COMPONENTS
   actionlib
   actionlib_msgs
+  behavior_tree_msgs
   genmsg
   message_generation
   roscpp
@@ -14,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
 )
 
+find_package(Boost REQUIRED COMPONENTS)
 
 add_action_files(
   DIRECTORY action
@@ -29,7 +31,9 @@ generate_messages(
 add_definitions(-Wall -lglut -lGL -std=c++0x)
 
 catkin_package(
-  CATKIN_DEPENDS actionlib_msgs
+  CATKIN_DEPENDS
+    actionlib_msgs
+    behavior_tree_msgs
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
 )
@@ -67,8 +71,6 @@ src/action_node.cpp
 src/behavior_tree.cpp
 src/condition_node.cpp
 src/control_node.cpp
-#src/decorator_retry_node.cpp
-#src/decorator_negation_node.cpp
 src/draw.cpp
 src/exceptions.cpp
 src/leaf_node.cpp
@@ -83,13 +85,20 @@ src/actions/action_test_node.cpp
 src/conditions/condition_test_node.cpp
 src/actions/ros_action.cpp
 src/conditions/ros_condition.cpp
+src/blackboard/blackboard.cpp
 src/dot_bt.cpp
 )
 
 # Compile the core library with name ${PROJECT_NAME}=behavior_tree_core
 # You can create executables which target to this library for using BTs
 add_library(${PROJECT_NAME} ${BTSrcLibrary} ${BTHeadLibrary})
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OPENGL_LIBRARIES} ${GLUT_LIBRARY})
+target_link_libraries(${PROJECT_NAME}
+  ${Boost_LIBRARIES}
+  ${catkin_LIBRARIES} 
+  ${OPENGL_LIBRARIES} 
+  ${GLUT_LIBRARY}
+)
+
 add_dependencies(${PROJECT_NAME} behavior_tree_core_generate_messages_cpp)
 
 add_executable(tree src/tree.cpp)

--- a/behavior_tree_core/CMakeLists.txt
+++ b/behavior_tree_core/CMakeLists.txt
@@ -6,12 +6,12 @@ project(behavior_tree_core)
 find_package(catkin REQUIRED COMPONENTS
   actionlib
   actionlib_msgs
+  genmsg
   message_generation
   roscpp
   rospy
-  std_msgs
   roslaunch
-  genmsg
+  std_msgs
 )
 
 
@@ -31,6 +31,7 @@ add_definitions(-Wall -lglut -lGL -std=c++0x)
 catkin_package(
   CATKIN_DEPENDS actionlib_msgs
   INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
 )
 
 
@@ -56,13 +57,6 @@ add_definitions(${OpenGL_DEFINITIONS})
 if(NOT OPENGL_FOUND)
     message(ERROR " OPENGL not found!")
 endif(NOT OPENGL_FOUND)
-
-#########################################################
-# FIND GTest
-#########################################################
-find_package(GTest)
-include_directories(${GTEST_INCLUDE_DIRS})
-
 
 INCLUDE_DIRECTORIES(${catkin_INCLUDE_DIRS} include)
 
@@ -101,23 +95,19 @@ add_dependencies(${PROJECT_NAME} behavior_tree_core_generate_messages_cpp)
 add_executable(tree src/tree.cpp)
 target_link_libraries(tree
   ${catkin_LIBRARIES}
-  ${PROJECT_NAME})
+  ${PROJECT_NAME}
+)
 
-add_executable(gtest_tree src/gtest/gtest_tree.cpp)
+catkin_add_gtest(gtest_tree src/gtest/gtest_tree.cpp)
 target_link_libraries(gtest_tree
   ${catkin_LIBRARIES}
   ${PROJECT_NAME}
-  ${GTEST_LIBRARIES})
+  ${GTest_LIBRARIES}
+)
 
 add_executable(gtest_ros src/gtest/external_ros_nodes_test.cpp)
 target_link_libraries(gtest_ros
   ${catkin_LIBRARIES}
   ${PROJECT_NAME}
-  ${GTEST_LIBRARIES})
-
-
-#add_executable(ros_test src/ros_test.cpp ${BTSrcLibrary} ${BTHeadLibrary})
-#target_link_libraries(ros_test ${catkin_LIBRARIES} ${OPENGL_LIBRARIES} ${GLUT_LIBRARY})
-#add_dependencies(ros_test behavior_tree_core_generate_messages_cpp)
-
+)
 

--- a/behavior_tree_core/CMakeLists.txt
+++ b/behavior_tree_core/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(behavior_tree_core)
 
-
-
 find_package(catkin REQUIRED COMPONENTS
   actionlib
   actionlib_msgs
@@ -10,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   genmsg
   message_generation
   roscpp
+  roslint
   rospy
   roslaunch
   std_msgs
@@ -28,7 +27,7 @@ generate_messages(
 )
 
 
-add_definitions(-Wall -lglut -lGL -std=c++0x)
+add_definitions(-Wall -lglut -lGL -std=c++11)
 
 catkin_package(
   CATKIN_DEPENDS
@@ -38,7 +37,7 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
 )
 
-
+roslint_cpp()
 
 #########################################################
 # FIND GLUT

--- a/behavior_tree_core/include/actions/action.h
+++ b/behavior_tree_core/include/actions/action.h
@@ -1,3 +1,15 @@
+/* Copyright (C) 2015-2017 Michele Colledanchise - All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 #ifndef ACTIONS_ACTION_H
 #define ACTIONS_ACTION_H
 
@@ -13,40 +25,40 @@ namespace BT
 class Action : public ActionNode
 {
 protected:
-	// Blackboard pointer
-	boost::shared_ptr<BT::Blackboard> blkbrd_ptr_;
+    // Blackboard pointer
+    boost::shared_ptr<BT::Blackboard> blkbrd_ptr_;
 
-	// Node Status
-	BT::ReturnStatus status_;
+    // Node Status
+    BT::ReturnStatus status_;
 public:
     // Constructor
     Action(std::string name, boost::shared_ptr<BT::Blackboard> blkbrd_ptr)
       :  ActionNode::ActionNode(name),
          blkbrd_ptr_(blkbrd_ptr)
     {
-	    thread_ = std::thread(&Action::WaitForTick, this);
+        thread_ = std::thread(&Action::WaitForTick, this);
     }
 
     void WaitForTick()
     {
-    	while (true)
-    	{
-    		tick_engine.Wait();
+        while (true)
+        {
+            tick_engine.Wait();
 
-    		set_status(BT::RUNNING);
-    		status_ = BT::RUNNING;
+            set_status(BT::RUNNING);
+            status_ = BT::RUNNING;
 
-    		OnTick();
-    	}
+            OnTick();
+        }
     }
 
-	void Halt()
-	{
-	    set_status(BT::HALTED);
-	}
+    void Halt()
+    {
+        set_status(BT::HALTED);
+    }
 
-	// Implement what happens on a tick in derived classes
-	virtual void OnTick() = 0;
+    // Implement what happens on a tick in derived classes
+    virtual void OnTick() = 0;
 
     ~Action()
     {}

--- a/behavior_tree_core/include/actions/action.h
+++ b/behavior_tree_core/include/actions/action.h
@@ -1,0 +1,56 @@
+#ifndef ACTIONS_ACTION_H
+#define ACTIONS_ACTION_H
+
+#include <action_node.h>
+#include "blackboard/blackboard.h"
+
+#include <boost/shared_ptr.hpp>
+
+#include <string>
+
+namespace BT
+{
+class Action : public ActionNode
+{
+protected:
+	// Blackboard pointer
+	boost::shared_ptr<BT::Blackboard> blkbrd_ptr_;
+
+	// Node Status
+	BT::ReturnStatus status_;
+public:
+    // Constructor
+    Action(std::string name, boost::shared_ptr<BT::Blackboard> blkbrd_ptr)
+      :  ActionNode::ActionNode(name),
+         blkbrd_ptr_(blkbrd_ptr)
+    {
+	    thread_ = std::thread(&Action::WaitForTick, this);
+    }
+
+    void WaitForTick()
+    {
+    	while (true)
+    	{
+    		tick_engine.Wait();
+
+    		set_status(BT::RUNNING);
+    		status_ = BT::RUNNING;
+
+    		OnTick();
+    	}
+    }
+
+	void Halt()
+	{
+	    set_status(BT::HALTED);
+	}
+
+	// Implement what happens on a tick in derived classes
+	virtual void OnTick() = 0;
+
+    ~Action()
+    {}
+};
+
+}  // namespace BT
+#endif  // ACTIONS_ACTION_H

--- a/behavior_tree_core/include/behavior_tree.h
+++ b/behavior_tree_core/include/behavior_tree.h
@@ -28,7 +28,7 @@
 #include <conditions/ros_condition.h>
 #include "blackboard/blackboard.h"
 
-#include "behavior_tree_msgs/SetKvPairs.h"
+#include "behavior_tree_msgs/UpdateBlackboard.h"
 
 #include <boost/shared_ptr.hpp>
 
@@ -43,9 +43,9 @@
 #include "ros/ros.h"
 #include "std_msgs/UInt8.h"
 
-bool update_blackboard(behavior_tree_msgs::SetKvPairs::Request &req,
-                 behavior_tree_msgs::SetKvPairs::Response &res,
-                 boost::shared_ptr<BT::Blackboard> blkbrd_ptr);
+bool update_blackboard(behavior_tree_msgs::UpdateBlackboard::Request &req,
+                       behavior_tree_msgs::UpdateBlackboard::Response &res,
+                       boost::shared_ptr<BT::Blackboard> blkbrd_ptr);
 
 void Execute(BT::ControlNode* root,
 	         int TickPeriod_milliseconds);

--- a/behavior_tree_core/include/behavior_tree.h
+++ b/behavior_tree_core/include/behavior_tree.h
@@ -13,10 +13,6 @@
 #ifndef BEHAVIOR_TREE_H
 #define BEHAVIOR_TREE_H
 
-
-
-
-
 #include <draw.h>
 
 #include <parallel_node.h>
@@ -26,12 +22,15 @@
 #include <sequence_node_with_memory.h>
 #include <fallback_node_with_memory.h>
 
-
 #include <actions/action_test_node.h>
 #include <conditions/condition_test_node.h>
 #include <actions/ros_action.h>
 #include <conditions/ros_condition.h>
+#include "blackboard/blackboard.h"
 
+#include "behavior_tree_msgs/SetKvPairs.h"
+
+#include <boost/shared_ptr.hpp>
 
 #include <exceptions.h>
 
@@ -44,7 +43,16 @@
 #include "ros/ros.h"
 #include "std_msgs/UInt8.h"
 
-void Execute(BT::ControlNode* root, int TickPeriod_milliseconds);
+bool update_blackboard(behavior_tree_msgs::SetKvPairs::Request &req,
+                 behavior_tree_msgs::SetKvPairs::Response &res,
+                 boost::shared_ptr<BT::Blackboard> blkbrd_ptr);
 
+void Execute(BT::ControlNode* root,
+	         int TickPeriod_milliseconds);
+
+void Execute(BT::ControlNode* root,
+	         int TickPeriod_milliseconds,
+	         ros::NodeHandle& nh,
+	         boost::shared_ptr<BT::Blackboard> bklbrd_ptr = boost::shared_ptr<BT::Blackboard>());
 
 #endif  // BEHAVIOR_TREE_H

--- a/behavior_tree_core/include/behavior_tree.h
+++ b/behavior_tree_core/include/behavior_tree.h
@@ -48,11 +48,11 @@ bool update_blackboard(behavior_tree_msgs::UpdateBlackboard::Request &req,
                        boost::shared_ptr<BT::Blackboard> blkbrd_ptr);
 
 void Execute(BT::ControlNode* root,
-	         int TickPeriod_milliseconds);
+             int TickPeriod_milliseconds);
 
 void Execute(BT::ControlNode* root,
-	         int TickPeriod_milliseconds,
-	         ros::NodeHandle& nh,
-	         boost::shared_ptr<BT::Blackboard> bklbrd_ptr = boost::shared_ptr<BT::Blackboard>());
+             int TickPeriod_milliseconds,
+             ros::NodeHandle& nh,
+             boost::shared_ptr<BT::Blackboard> bklbrd_ptr = boost::shared_ptr<BT::Blackboard>());
 
 #endif  // BEHAVIOR_TREE_H

--- a/behavior_tree_core/include/blackboard/blackboard.h
+++ b/behavior_tree_core/include/blackboard/blackboard.h
@@ -1,0 +1,46 @@
+#include <boost/any.hpp>
+#include <map>
+#include <utility>
+#include <vector>
+
+#ifndef BLACKBOARD_BLACKBOARD_H
+#define BLACKBOARD_BLACKBOARD_H
+
+namespace BT
+{
+class Blackboard
+{
+private:
+	std::map<std::string, boost::any> map_;
+
+public:
+	explicit Blackboard(std::vector< std::pair<std::string, boost::any> > kv_pairs);
+
+	template <typename T>
+	void add_kv(std::string key, T value)
+	{
+		if (!key_exists(key))
+			map_.insert(std::pair<std::string, boost::any>(key, value));
+	}
+
+	template <typename T>
+	inline T get_value(std::string key) const
+	{
+		return boost::any_cast<T>(map_.find(key)->second);
+	}
+
+	template<typename T>
+	inline void update_kv(std::string key, T value)
+	{
+		if (key_exists(key))
+			map_.find(key)->second = value;
+	}
+
+	bool key_exists(std::string key) const;
+
+	~Blackboard()
+	{}
+
+};
+}  //namespace BT
+#endif  // BLACKBOARD_BLACKBOARD_H

--- a/behavior_tree_core/include/blackboard/blackboard.h
+++ b/behavior_tree_core/include/blackboard/blackboard.h
@@ -21,13 +21,13 @@ public:
 	explicit Blackboard(std::vector< std::pair<std::string, boost::any> > kv_pairs);
 
 	template <typename T>
-	void add_kv(std::string key, T value)
+	bool add_kv(std::string key, T value)
 	{
-		if (!key_exists(key))
-		{
-			boost::mutex::scoped_lock lock(mutex_);
+		boost::mutex::scoped_lock lock(mutex_);
+		std::pair<std::map<std::string, boost::any>::iterator, bool> result =
 			map_.insert(std::pair<std::string, boost::any>(key, value));
-		}
+
+		return result.second;
 	}
 
 	template <typename T>
@@ -45,6 +45,8 @@ public:
 			boost::mutex::scoped_lock lock(mutex_);
 			map_.find(key)->second = value;
 		}
+		else
+			add_kv<T>(key, value);
 	}
 
 	bool key_exists(std::string key) const;

--- a/behavior_tree_core/include/blackboard/blackboard.h
+++ b/behavior_tree_core/include/blackboard/blackboard.h
@@ -1,4 +1,6 @@
 #include <boost/any.hpp>
+#include <boost/thread/mutex.hpp>
+
 #include <map>
 #include <utility>
 #include <vector>
@@ -10,8 +12,10 @@ namespace BT
 {
 class Blackboard
 {
-private:
+protected:
 	std::map<std::string, boost::any> map_;
+
+	mutable boost::mutex mutex_;
 
 public:
 	explicit Blackboard(std::vector< std::pair<std::string, boost::any> > kv_pairs);
@@ -20,12 +24,16 @@ public:
 	void add_kv(std::string key, T value)
 	{
 		if (!key_exists(key))
+		{
+			boost::mutex::scoped_lock lock(mutex_);
 			map_.insert(std::pair<std::string, boost::any>(key, value));
+		}
 	}
 
 	template <typename T>
 	inline T get_value(std::string key) const
 	{
+		boost::mutex::scoped_lock lock(mutex_);
 		return boost::any_cast<T>(map_.find(key)->second);
 	}
 
@@ -33,7 +41,10 @@ public:
 	inline void update_kv(std::string key, T value)
 	{
 		if (key_exists(key))
+		{
+			boost::mutex::scoped_lock lock(mutex_);
 			map_.find(key)->second = value;
+		}
 	}
 
 	bool key_exists(std::string key) const;

--- a/behavior_tree_core/include/blackboard/blackboard.h
+++ b/behavior_tree_core/include/blackboard/blackboard.h
@@ -1,59 +1,61 @@
-#include <boost/any.hpp>
-#include <boost/thread/mutex.hpp>
-
-#include <map>
-#include <utility>
-#include <vector>
+/* Copyright (C) 2015-2017 Michele Colledanchise - All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
 
 #ifndef BLACKBOARD_BLACKBOARD_H
 #define BLACKBOARD_BLACKBOARD_H
+
+#include <boost/any.hpp>
+#include <boost/thread/mutex.hpp>
+
+#include <stdexcept>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace BT
 {
 class Blackboard
 {
 protected:
-	std::map<std::string, boost::any> map_;
+    std::map<std::string, boost::any> map_;
 
-	mutable boost::mutex mutex_;
+    mutable boost::mutex mutex_;
 
 public:
-	explicit Blackboard(std::vector< std::pair<std::string, boost::any> > kv_pairs);
+    explicit Blackboard(std::vector< std::pair<std::string, boost::any> > kv_pairs);
 
-	template <typename T>
-	bool add_kv(std::string key, T value)
-	{
-		boost::mutex::scoped_lock lock(mutex_);
-		std::pair<std::map<std::string, boost::any>::iterator, bool> result =
-			map_.insert(std::pair<std::string, boost::any>(key, value));
+    template <typename T>
+    inline T GetValue(std::string key) const
+    {
+        if (!KeyExists(key))
+            throw std::invalid_argument("Key " + key + " does not exist");
 
-		return result.second;
-	}
+        boost::mutex::scoped_lock lock(mutex_);
+        return boost::any_cast<T>(map_.find(key)->second);
+    }
 
-	template <typename T>
-	inline T get_value(std::string key) const
-	{
-		boost::mutex::scoped_lock lock(mutex_);
-		return boost::any_cast<T>(map_.find(key)->second);
-	}
+    template<typename T>
+    inline void UpdateKv(std::string key, T value)
+    {
+        // Updates key-value pair if exists, else adds it to map_
+        boost::mutex::scoped_lock lock(mutex_);
+        map_[key] = value;
+    }
 
-	template<typename T>
-	inline void update_kv(std::string key, T value)
-	{
-		if (key_exists(key))
-		{
-			boost::mutex::scoped_lock lock(mutex_);
-			map_.find(key)->second = value;
-		}
-		else
-			add_kv<T>(key, value);
-	}
+    bool KeyExists(std::string key) const;
 
-	bool key_exists(std::string key) const;
-
-	~Blackboard()
-	{}
-
+    ~Blackboard()
+    {}
 };
-}  //namespace BT
+}  // namespace BT
 #endif  // BLACKBOARD_BLACKBOARD_H

--- a/behavior_tree_core/include/conditions/condition.h
+++ b/behavior_tree_core/include/conditions/condition.h
@@ -1,0 +1,22 @@
+#ifndef CONDITIONS_CONDITION_H
+#define CONDITIONS_CONDITION_H
+
+#include <condition_node.h>
+#include <string>
+
+namespace BT
+{
+class Condition : public ConditionNode
+{
+
+public:
+    // Constructor
+    Condition(std::string name)
+      :  ConditionNode::ConditionNode(name)
+    {}
+
+    ~Condition();
+};
+
+}  // namespace BT
+#endif  // CONDITIONS_CONDITION_H

--- a/behavior_tree_core/include/conditions/condition.h
+++ b/behavior_tree_core/include/conditions/condition.h
@@ -1,3 +1,15 @@
+/* Copyright (C) 2015-2017 Michele Colledanchise - All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 #ifndef CONDITIONS_CONDITION_H
 #define CONDITIONS_CONDITION_H
 
@@ -12,7 +24,6 @@ namespace BT
 {
 class Condition : public ConditionNode
 {
-
 public:
     // Constructor
     Condition(std::string name, boost::shared_ptr<BT::Blackboard> blkbrd_ptr)
@@ -23,7 +34,7 @@ public:
     ~Condition();
 
 protected:
-	boost::shared_ptr<BT::Blackboard> blkbrd_ptr_;
+    boost::shared_ptr<BT::Blackboard> blkbrd_ptr_;
 };
 
 }  // namespace BT

--- a/behavior_tree_core/include/conditions/condition.h
+++ b/behavior_tree_core/include/conditions/condition.h
@@ -2,6 +2,10 @@
 #define CONDITIONS_CONDITION_H
 
 #include <condition_node.h>
+#include "blackboard/blackboard.h"
+
+#include <boost/shared_ptr.hpp>
+
 #include <string>
 
 namespace BT
@@ -11,11 +15,15 @@ class Condition : public ConditionNode
 
 public:
     // Constructor
-    Condition(std::string name)
-      :  ConditionNode::ConditionNode(name)
+    Condition(std::string name, boost::shared_ptr<BT::Blackboard> blkbrd_ptr)
+      :  ConditionNode::ConditionNode(name),
+         blkbrd_ptr_(blkbrd_ptr)
     {}
 
     ~Condition();
+
+protected:
+	boost::shared_ptr<BT::Blackboard> blkbrd_ptr_;
 };
 
 }  // namespace BT

--- a/behavior_tree_core/include/dot_bt.h
+++ b/behavior_tree_core/include/dot_bt.h
@@ -161,7 +161,7 @@ private:
    * @brief A ROS publisher for publishing DotBt::dot_file_.
    */
   ros::Publisher dotbt_publisher_;
-  
+
   /**
    * @brief The root of the Behavior Tree.
    */

--- a/behavior_tree_core/include/tick_engine.h
+++ b/behavior_tree_core/include/tick_engine.h
@@ -13,7 +13,7 @@
 #ifndef TICK_ENGINE_H
 #define TICK_ENGINE_H
 
-#include <condition_variable>
+#include <condition_variable>  // NOLINT
 
 class TickEngine
 {

--- a/behavior_tree_core/include/tree_node.h
+++ b/behavior_tree_core/include/tree_node.h
@@ -41,7 +41,7 @@
 
 #endif
 
-   #define DEBUG  // uncomment this line if you want to print debug messages
+#define DEBUG  // uncomment this line if you want to print debug messages
 
 #ifdef DEBUG
   // #define DEBUG_STDERR(x) (std::cerr << (x))
@@ -58,11 +58,10 @@
 
 #include <string>
 
-#include <thread>
-#include <chrono>
-#include <mutex>
-#include <condition_variable>
-
+#include <thread>  // NOLINT
+#include <chrono>  // NOLINT
+#include <mutex>  // NOLINT
+#include <condition_variable>  // NOLINT
 
 #include <tick_engine.h>
 #include <exceptions.h>

--- a/behavior_tree_core/package.xml
+++ b/behavior_tree_core/package.xml
@@ -9,19 +9,22 @@
   <author>Michele Colledanchise</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>actionlib</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>behavior_tree_msgs</build_depend>
+  <build_depend>glut</build_depend>
+  <build_depend>libxi-dev</build_depend>
+  <build_depend>libxmu-dev</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>actionlib</build_depend>
-  <build_depend>actionlib_msgs</build_depend>
-  <build_depend>glut</build_depend>
-  <build_depend>libxmu-dev</build_depend>
-  <build_depend>libxi-dev</build_depend>
+
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
+  <run_depend>behavior_tree_msgs</run_depend>
   <run_depend>gtest</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>

--- a/behavior_tree_core/package.xml
+++ b/behavior_tree_core/package.xml
@@ -22,6 +22,7 @@
   <build_depend>libxi-dev</build_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
+  <run_depend>gtest</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>roslib</run_depend>

--- a/behavior_tree_core/package.xml
+++ b/behavior_tree_core/package.xml
@@ -19,6 +19,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslib</build_depend>
+  <build_depend>roslint</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
 

--- a/behavior_tree_core/src/behavior_tree.cpp
+++ b/behavior_tree_core/src/behavior_tree.cpp
@@ -11,7 +11,7 @@
 */
 
 
-#include<behavior_tree.h>
+#include <behavior_tree.h>
 #include <dot_bt.h>
 #include <ros/ros.h>
 

--- a/behavior_tree_core/src/blackboard/blackboard.cpp
+++ b/behavior_tree_core/src/blackboard/blackboard.cpp
@@ -7,10 +7,8 @@ namespace BT
 {
 	Blackboard::Blackboard(std::vector<std::pair<std::string, boost::any>> kv_pairs)
 	{
-		for (std::vector<std::pair<std::string, boost::any>>::iterator it = kv_pairs.begin(); it != kv_pairs.end(); it++)
-		{
-			map_.insert(*it);
-		}
+		for (auto kv : kv_pairs)
+			map_.insert(kv);
 	}
 
 	bool Blackboard::key_exists(std::string key) const

--- a/behavior_tree_core/src/blackboard/blackboard.cpp
+++ b/behavior_tree_core/src/blackboard/blackboard.cpp
@@ -1,23 +1,35 @@
+/* Copyright (C) 2015-2017 Michele Colledanchise - All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 #include "blackboard/blackboard.h"
 
 #include <boost/any.hpp>
+
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace BT
 {
-	Blackboard::Blackboard(std::vector<std::pair<std::string, boost::any>> kv_pairs)
-	{
-		for (auto kv : kv_pairs)
-			map_.insert(kv);
-	}
+    Blackboard::Blackboard(std::vector<std::pair<std::string, boost::any>> kv_pairs)
+    {
+        for (auto kv : kv_pairs)
+            map_.insert(kv);
+    }
 
-	bool Blackboard::key_exists(std::string key) const
-	{
-		boost::mutex::scoped_lock lock(mutex_);
-		if (map_.find(key) == map_.end())
-			return false;
-		else
-			return true;
-	}
+    bool Blackboard::KeyExists(std::string key) const
+    {
+        boost::mutex::scoped_lock lock(mutex_);
+        return map_.find(key) != map_.end();
+    }
 
 }  // namespace BT

--- a/behavior_tree_core/src/blackboard/blackboard.cpp
+++ b/behavior_tree_core/src/blackboard/blackboard.cpp
@@ -15,6 +15,7 @@ namespace BT
 
 	bool Blackboard::key_exists(std::string key) const
 	{
+		boost::mutex::scoped_lock lock(mutex_);
 		if (map_.find(key) == map_.end())
 			return false;
 		else

--- a/behavior_tree_core/src/blackboard/blackboard.cpp
+++ b/behavior_tree_core/src/blackboard/blackboard.cpp
@@ -1,0 +1,24 @@
+#include "blackboard/blackboard.h"
+
+#include <boost/any.hpp>
+#include <utility>
+
+namespace BT
+{
+	Blackboard::Blackboard(std::vector<std::pair<std::string, boost::any>> kv_pairs)
+	{
+		for (std::vector<std::pair<std::string, boost::any>>::iterator it = kv_pairs.begin(); it != kv_pairs.end(); it++)
+		{
+			map_.insert(*it);
+		}
+	}
+
+	bool Blackboard::key_exists(std::string key) const
+	{
+		if (map_.find(key) == map_.end())
+			return false;
+		else
+			return true;
+	}
+
+}  // namespace BT

--- a/behavior_tree_core/src/control_node.cpp
+++ b/behavior_tree_core/src/control_node.cpp
@@ -32,7 +32,9 @@ void BT::ControlNode::AddChild(TreeNode* child)
 
         if (child->has_parent())
         {
-            throw BehaviorTreeException("'" + child->get_name() + " has a parent already. Please create different objects for multiple nodes. It makes the tinking/halting precedure easier.");
+            throw BehaviorTreeException("'" + child->get_name() +
+                " has a parent already. Please create different objects for multiple nodes."
+                "It makes the tinking/halting precedure easier.");
         }
 
     child->set_has_parent(true);

--- a/behavior_tree_core/src/dot_bt.cpp
+++ b/behavior_tree_core/src/dot_bt.cpp
@@ -20,9 +20,13 @@
 
 #include <dot_bt.h>
 #include <control_node.h>
+
 #include <std_msgs/String.h>
-#include <cctype>
+
 #include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
 
 namespace BT
 {
@@ -67,10 +71,12 @@ std::string DotBt::defineNodeDot(TreeNode* node, const std::string& alias)
       output += "[label=\"D\" penwidth=\"2\" shape=\"diamond\"";
       break;
     case BT::ACTION:
-      output += "[label=\"" + node->get_name() + "\" penwidth=\"2\" shape=\"box\" fillcolor=\"palegreen\" style=\"filled\"";
+      output += "[label=\"" + node->get_name() +
+      "\" penwidth=\"2\" shape=\"box\" fillcolor=\"palegreen\" style=\"filled\"";
       break;
     case BT::CONDITION:
-      output += "[label=\"" + node->get_name() + "\" penwidth=\"2\" shape=\"ellipse\" fillcolor=\"khaki1\" style=\"filled\"";
+      output += "[label=\"" + node->get_name() +
+      "\" penwidth=\"2\" shape=\"ellipse\" fillcolor=\"khaki1\" style=\"filled\"";
       break;
     default:
       break;
@@ -149,7 +155,6 @@ void DotBt::produceDot(TreeNode* node, TreeNode* parent, const std::string& pare
     std::vector<TreeNode *> children = n->GetChildren();
     for (unsigned int i = 0; i < children.size(); i++)
     {
-
 //        if (children[i]->has_alias())
 //        {
 //            // cheking if I need to halt the child (has alias)

--- a/behavior_tree_core/src/draw.cpp
+++ b/behavior_tree_core/src/draw.cpp
@@ -489,7 +489,6 @@ void drawTree(BT::ControlNode* tree_)
         glutInit(&argc, argv);
         init = true;
         glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGBA | GLUT_DEPTH | GLUT_MULTISAMPLE);  //  Antialiasing
-        glEnable(GL_MULTISAMPLE);
     }
     tree = tree_;
     depth = tree->Depth();

--- a/behavior_tree_msgs/CMakeLists.txt
+++ b/behavior_tree_msgs/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(behavior_tree_msgs)
+
+find_package(catkin REQUIRED COMPONENTS
+  std_msgs
+  message_generation
+)
+
+add_message_files(
+  FILES
+    KeyValue.msg
+)
+
+add_service_files(
+  FILES
+    SetKvPairs.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+    std_msgs
+)
+
+catkin_package(
+ CATKIN_DEPENDS
+   std_msgs
+   message_runtime
+)

--- a/behavior_tree_msgs/CMakeLists.txt
+++ b/behavior_tree_msgs/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(behavior_tree_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-  std_msgs
   message_generation
 )
 
@@ -16,13 +15,9 @@ add_service_files(
     UpdateBlackboard.srv
 )
 
-generate_messages(
-  DEPENDENCIES
-    std_msgs
-)
+generate_messages()
 
 catkin_package(
  CATKIN_DEPENDS
-   std_msgs
    message_runtime
 )

--- a/behavior_tree_msgs/CMakeLists.txt
+++ b/behavior_tree_msgs/CMakeLists.txt
@@ -13,7 +13,7 @@ add_message_files(
 
 add_service_files(
   FILES
-    SetKvPairs.srv
+    UpdateBlackboard.srv
 )
 
 generate_messages(

--- a/behavior_tree_msgs/msg/KeyValue.msg
+++ b/behavior_tree_msgs/msg/KeyValue.msg
@@ -1,0 +1,8 @@
+uint8 BOOL=0
+uint8 INT=1
+uint8 DOUBLE=2
+uint8 STRING=3
+
+string key
+string value
+uint8 value_type

--- a/behavior_tree_msgs/package.xml
+++ b/behavior_tree_msgs/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package>
+  <name>behavior_tree_msgs</name>
+  <version>0.0.0</version>
+  <description>Contains messages for updating Blackboard</description>
+
+  <maintainer email="somesh@aandkrobotics.com">Somesh Daga</maintainer>
+
+  <license>MIT</license>
+
+  <author email="somesh@aandkrobotics.com">Somesh Daga</author>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <run_depend>message_runtime</run_depend>
+  <run_depend>std_msgs</run_depend>
+  
+  <export>
+  </export>
+</package>

--- a/behavior_tree_msgs/srv/SetKvPairs.srv
+++ b/behavior_tree_msgs/srv/SetKvPairs.srv
@@ -1,3 +1,0 @@
-behavior_tree_msgs/KeyValue[] kv_pairs
----
-bool received

--- a/behavior_tree_msgs/srv/SetKvPairs.srv
+++ b/behavior_tree_msgs/srv/SetKvPairs.srv
@@ -1,0 +1,3 @@
+behavior_tree_msgs/KeyValue[] kv_pairs
+---
+bool received

--- a/behavior_tree_msgs/srv/UpdateBlackboard.srv
+++ b/behavior_tree_msgs/srv/UpdateBlackboard.srv
@@ -1,0 +1,7 @@
+behavior_tree_msgs/KeyValue[] kv_pairs
+---
+uint8 SUCCESS=0
+uint8 INVALID_KVS=1
+
+uint8 updated
+string[] keys_failed


### PR DESCRIPTION
This PR has the following features:

- Fixes Gtest/Run Errors that created issues with running example code
- Adds a Blackboard Implementation with the associated messages and service types defined in a new package `behavior_tree_msgs`
- Adds a `Condition` node that does not require the use of an action client and integrates with the blackboard implementation
- Adds a `Action` node that does not require the use of an action client and integrates with the blackboard implementation